### PR TITLE
fix supported bash version in test-patch prerequisites document

### DIFF
--- a/precommit/docs/precommit-basic.md
+++ b/precommit/docs/precommit-basic.md
@@ -34,7 +34,7 @@ test-patch has the following requirements:
 
 * Maven-based project (and maven installed)
 * git-based project (and git installed)
-* bash v3.x or higher
+* bash v3.2 or higher
 * findbugs 3.x installed
 * shellcheck installed
 * GNU diff


### PR DESCRIPTION
Hi Allen, I'd like to send a very small PR.
test-patch doesn't work on bash 3.1, because the right side of regex operator must be quoted on that version. I'm using Git for Windows 1.9.5 when I'm on Windows, and its bash version is 3.1, so the following error occurs:

```
C:\hadoop\dev-support\test-patch.sh: line 499: conditional binary operator expected
C:\hadoop\dev-support\test-patch.sh: line 499: syntax error near `=~'
C:\hadoop\dev-support\test-patch.sh: line 499: `    if [[ ${line} =~ ^\+\+\+ ]]; then'
```